### PR TITLE
Fixes #1 typo in exercise command

### DIFF
--- a/ExXX_LastnameOfMembers.tex
+++ b/ExXX_LastnameOfMembers.tex
@@ -14,6 +14,10 @@
 % \input: Fügt KEINEN Seitenumbruch nach dem Text ein
 \input{../../../templates/AbgabenTemplate/Usepackage.tex}
 \input{../../../templates/AbgabenTemplate/FormatAndHeader.tex}
+
+%Setzen der Übungsblatt Nummer
+\setcounter{sheetnr}{1}
+
 % Beginn des eigentlichen Dokuments
 \begin{document}
 % Nutze den \excercise{Aufgabenname} Befehl, um eine neue Aufgabe zu beginnen.

--- a/ExXX_LastnameOfMembers.tex
+++ b/ExXX_LastnameOfMembers.tex
@@ -12,9 +12,8 @@
 % Mit den \include und \input Befehlen können Dateien eingebunden werden:
 % \include: Fügt einen Seitenumbruch nach dem Text ein
 % \input: Fügt KEINEN Seitenumbruch nach dem Text ein
-\input{Usepackage.tex}
-\input{FormatAndHeader.tex}
-
+\input{../../../templates/AbgabenTemplate/Usepackage.tex}
+\input{../../../templates/AbgabenTemplate/FormatAndHeader.tex}
 % Beginn des eigentlichen Dokuments
 \begin{document}
 % Nutze den \excercise{Aufgabenname} Befehl, um eine neue Aufgabe zu beginnen.

--- a/ExXX_LastnameOfMembers.tex
+++ b/ExXX_LastnameOfMembers.tex
@@ -17,7 +17,7 @@
 
 % Beginn des eigentlichen Dokuments
 \begin{document}
-% Nutze den \excercise{Aufgabenname} Befehl, um eine neue Aufgabe zu beginnen.
+% Nutze den \exercise{Aufgabenname} Befehl, um eine neue Aufgabe zu beginnen.
 % Möchtest du eine Aufgabe in der Nummerierung überspringen, schreibe vor der Aufgabe: \stepcounter{exnum}
 % Möchtest du die Nummer einer Aufgabe auf eine beliebige Zahl x setzen, schreibe vor der Aufgabe: \setcounter{exnum}{x}
 

--- a/ExXX_LastnameOfMembers.tex
+++ b/ExXX_LastnameOfMembers.tex
@@ -1,28 +1,28 @@
-% LaTeX Template für Abgaben an der Universität Stuttgart
+% LaTeX Template fÃ¼r Abgaben an der UniversitÃ¤t Stuttgart
 % Autor: Sandro Speth
 % Bei Fragen: Sandro.Speth@studi.informatik.uni-stuttgart.de
 %-----------------------------------------------------------
-% Hauptmodul des Templates: Hier können andere Dateien eingebunden werden
+% Hauptmodul des Templates: Hier kÃ¶nnen andere Dateien eingebunden werden
 % oder Inhalte direkt rein geschrieben werden.
 % Kompiliere dieses Modul um eine PDF zu erzeugen.
 
-% Dokumentenart. Ersetze 12pt, falls die Schriftgröße anzupassen ist.
+% Dokumentenart. Ersetze 12pt, falls die SchriftgrÃ¶ÃŸe anzupassen ist.
 \documentclass[12pt]{scrartcl}
 % Einbinden der Pakete, des Headers und der Formatierung.
-% Mit den \include und \input Befehlen können Dateien eingebunden werden:
-% \include: Fügt einen Seitenumbruch nach dem Text ein
-% \input: Fügt KEINEN Seitenumbruch nach dem Text ein
+% Mit den \include und \input Befehlen kÃ¶nnen Dateien eingebunden werden:
+% \include: FÃ¼gt einen Seitenumbruch nach dem Text ein
+% \input: FÃ¼gt KEINEN Seitenumbruch nach dem Text ein
 \input{../../../templates/AbgabenTemplate/Usepackage.tex}
 \input{../../../templates/AbgabenTemplate/FormatAndHeader.tex}
 
-%Setzen der Übungsblatt Nummer
+%Setzen der Ãœbungsblatt Nummer
 \setcounter{sheetnr}{1}
 
 % Beginn des eigentlichen Dokuments
 \begin{document}
 % Nutze den \excercise{Aufgabenname} Befehl, um eine neue Aufgabe zu beginnen.
-% Möchtest du eine Aufgabe in der Nummerierung überspringen, schreibe vor der Aufgabe: \stepcounter{exnum}
-% Möchtest du die Nummer einer Aufgabe auf eine beliebige Zahl x setzen, schreibe vor der Aufgabe: \setcounter{exnum}{x}
+% MÃ¶chtest du eine Aufgabe in der Nummerierung Ã¼berspringen, schreibe vor der Aufgabe: \stepcounter{exnum}
+% MÃ¶chtest du die Nummer einer Aufgabe auf eine beliebige Zahl x setzen, schreibe vor der Aufgabe: \setcounter{exnum}{x}
 
 % Aufgabe 1
 \exercise{Lorem ipsum}

--- a/ExXX_LastnameOfMembers.tps
+++ b/ExXX_LastnameOfMembers.tps
@@ -11,14 +11,14 @@ MaxPos.x=-1
 MaxPos.y=-1
 NormalPos.left=4
 NormalPos.top=26
-NormalPos.right=1362
-NormalPos.bottom=446
+NormalPos.right=632
+NormalPos.bottom=665
 Class=LaTeXView
 Document=ExXX_LastnameOfMembers.tex
 
 [Frame0_View0,0]
-TopLine=0
-Cursor=2
+TopLine=150
+Cursor=765
 
 [Frame1]
 Flags=0
@@ -29,8 +29,8 @@ MaxPos.x=-1
 MaxPos.y=-1
 NormalPos.left=4
 NormalPos.top=26
-NormalPos.right=1362
-NormalPos.bottom=446
+NormalPos.right=632
+NormalPos.bottom=665
 Class=LaTeXView
 Document=Usepackage.tex
 
@@ -47,8 +47,8 @@ MaxPos.x=-1
 MaxPos.y=-1
 NormalPos.left=4
 NormalPos.top=26
-NormalPos.right=1362
-NormalPos.bottom=446
+NormalPos.right=632
+NormalPos.bottom=665
 Class=LaTeXView
 Document=FormatAndHeader.tex
 
@@ -58,5 +58,5 @@ Cursor=59
 
 [SessionInfo]
 FrameCount=3
-ActiveFrame=1
+ActiveFrame=0
 

--- a/ExXX_LastnameOfMembers.tps
+++ b/ExXX_LastnameOfMembers.tps
@@ -10,14 +10,14 @@ MinPos.y=-1
 MaxPos.x=-1
 MaxPos.y=-1
 NormalPos.left=4
-NormalPos.top=26
-NormalPos.right=632
-NormalPos.bottom=665
+NormalPos.top=32
+NormalPos.right=2436
+NormalPos.bottom=847
 Class=LaTeXView
 Document=ExXX_LastnameOfMembers.tex
 
 [Frame0_View0,0]
-TopLine=150
+TopLine=92
 Cursor=765
 
 [Frame1]
@@ -28,9 +28,9 @@ MinPos.y=-1
 MaxPos.x=-1
 MaxPos.y=-1
 NormalPos.left=4
-NormalPos.top=26
-NormalPos.right=632
-NormalPos.bottom=665
+NormalPos.top=32
+NormalPos.right=2436
+NormalPos.bottom=847
 Class=LaTeXView
 Document=Usepackage.tex
 
@@ -46,17 +46,17 @@ MinPos.y=-1
 MaxPos.x=-1
 MaxPos.y=-1
 NormalPos.left=4
-NormalPos.top=26
-NormalPos.right=632
-NormalPos.bottom=665
+NormalPos.top=32
+NormalPos.right=2436
+NormalPos.bottom=847
 Class=LaTeXView
 Document=FormatAndHeader.tex
 
 [Frame2_View0,0]
-TopLine=0
-Cursor=59
+TopLine=9
+Cursor=1258
 
 [SessionInfo]
 FrameCount=3
-ActiveFrame=0
+ActiveFrame=2
 

--- a/ExXX_LastnameOfMembers.tps
+++ b/ExXX_LastnameOfMembers.tps
@@ -17,8 +17,8 @@ Class=LaTeXView
 Document=ExXX_LastnameOfMembers.tex
 
 [Frame0_View0,0]
-TopLine=92
-Cursor=765
+TopLine=0
+Cursor=920
 
 [Frame1]
 Flags=0
@@ -53,7 +53,7 @@ Class=LaTeXView
 Document=FormatAndHeader.tex
 
 [Frame2_View0,0]
-TopLine=9
+TopLine=3
 Cursor=1258
 
 [SessionInfo]

--- a/ExXX_LastnameOfMembers.tps
+++ b/ExXX_LastnameOfMembers.tps
@@ -17,7 +17,7 @@ Class=LaTeXView
 Document=ExXX_LastnameOfMembers.tex
 
 [Frame0_View0,0]
-TopLine=0
+TopLine=96
 Cursor=920
 
 [Frame1]
@@ -53,10 +53,10 @@ Class=LaTeXView
 Document=FormatAndHeader.tex
 
 [Frame2_View0,0]
-TopLine=3
+TopLine=9
 Cursor=1258
 
 [SessionInfo]
 FrameCount=3
-ActiveFrame=2
+ActiveFrame=0
 

--- a/FormatAndHeader.tex
+++ b/FormatAndHeader.tex
@@ -27,9 +27,9 @@
 % Formatierung der Kopfzeile
 % \ohead: Setzt rechten Teil der Kopfzeile mit
 % Namen und Matrikelnummern aller Bearbeiter
-\ohead{Max Mustermann (1234567)\\
-Klaus Kleber (1234568)\\
-Melanie Marshmallow (1234569)}
+\ohead{Simon Hauser (3230068) st148437@stud.uni-stuttgart.de\\
+Fabio Schmidberger (3255454) st149100@stud.uni-stuttgart.de\\
+Leon Kiefer (3230068) st148437@stud.uni-stuttgart.de}
 % \chead{} kann mittleren Kopfzeilen Teil sezten
 % \ihead: Setzt linken Teil der Kopfzeile mit
 % Modulnamen, Semester und Übungsblattnummer

--- a/FormatAndHeader.tex
+++ b/FormatAndHeader.tex
@@ -27,9 +27,10 @@
 % Formatierung der Kopfzeile
 % \ohead: Setzt rechten Teil der Kopfzeile mit
 % Namen und Matrikelnummern aller Bearbeiter
-\ohead{Simon Hauser (3230068) st148437@stud.uni-stuttgart.de\\
-Fabio Schmidberger (3255454) st149100@stud.uni-stuttgart.de\\
-Leon Kiefer (3230068) st148437@stud.uni-stuttgart.de}
+\ohead{ Simon Hauser (3228656) st148883@stud.uni-stuttgart.de\\
+ Fabio Schmidberger (3255454) st149100@stud.uni-stuttgart.de\\
+ Leon Kiefer (3230068) st148437@stud.uni-stuttgart.de
+}
 % \chead{} kann mittleren Kopfzeilen Teil sezten
 % \ihead: Setzt linken Teil der Kopfzeile mit
 % Modulnamen, Semester und Übungsblattnummer

--- a/Usepackage.tex
+++ b/Usepackage.tex
@@ -13,7 +13,7 @@
 \usepackage{listings}
 \usepackage[a4paper,lmargin={2cm},rmargin={2cm},tmargin={3.5cm},bmargin = {2.5cm},headheight = {4cm}]{geometry}
 \usepackage{amsmath,amssymb,amstext,amsthm}
-\usepackage[lined,algonl,boxed]{algorithm2e}
+\usepackage[linesnumbered,ruled]{algorithm2e}
 \usepackage{tikz}
 \usepackage{hyperref}
 \usepackage{url}
@@ -21,3 +21,6 @@
 \usepackage[headsepline]{scrpage2} 
 \pagestyle{scrheadings} 
 \usetikzlibrary{automata,positioning}
+
+
+


### PR DESCRIPTION
Im Kommentar der Datei `ExXX_LastnameOfMembers.tex` war ein Tippfehler der von diesem pull request behoben wird.

Im Kommentar wurde auf das Command `\excercise{Aufgabe}` verwiesen. Dabei ist das richtige Command `\exercise{Aufgabe}` .