### PR TITLE
replace outdated scrpage2 with scrlayer-scrpage

### DIFF
--- a/styles/Packages.tex
+++ b/styles/Packages.tex
@@ -22,6 +22,6 @@
 \usepackage{hyperref}
 \usepackage{url}
 \usepackage[inline]{enumitem} % Ermöglicht ändern der enum Item Zahlen
-\usepackage[headsepline]{scrpage2} 
+\usepackage[headsepline]{scrlayer-scrpage} 
 \pagestyle{scrheadings} 
 \usetikzlibrary{automata,positioning}


### PR DESCRIPTION
> As of 2015, the au­thor (Markus Kohm) con­sid­ers this pack­age (scrpage2) as ob­so­lete and rec­om­mends us­ing its suc­ces­sor scr­layer-scr­page in­stead

source: https://ctan.org/pkg/scrpage2

This resolves unnecessary warnings when compiling the ExXX_LastnameOfMembers.tex file provided by this template.